### PR TITLE
Visualize queue progression with loading bar

### DIFF
--- a/components/Button/Button.module.css
+++ b/components/Button/Button.module.css
@@ -3,7 +3,6 @@
     margin: 0;
     height: 25px;
     border: 0;
-    width: 160px;
     color: #333333;
     font-size: 13.33px;
     font-family: Poppins-Light;

--- a/components/QueueVisualization/QueueVisualization.module.css
+++ b/components/QueueVisualization/QueueVisualization.module.css
@@ -1,0 +1,22 @@
+.qVis {
+    text-align: center;
+    width: 300px;
+    position: relative;
+    border: 1px solid #33333330;
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+.full {
+    position: absolute;
+    background-color: #FFFD74;
+    top: 0;
+    bottom: 0;
+    z-index: 0;
+}
+
+.text {
+    font-size: 13.33px;
+    position: relative;
+    z-index: 1;
+}

--- a/components/QueueVisualization/index.js
+++ b/components/QueueVisualization/index.js
@@ -1,0 +1,20 @@
+import React from 'react'
+
+import styles from './QueueVisualization.module.css'
+
+const QueueVisualization = ({queueLength, civSize}) => {
+    const percentage = queueLength && civSize ? ((queueLength / civSize) * 100) : 0
+
+    const fullStyle = {
+        width: `${percentage}%`,
+    }
+
+    return (
+        <div className={styles.qVis}>
+            <div className={styles.full} style={fullStyle}></div>
+            <span className={styles.text}>{queueLength} / {civSize}</span>
+        </div>
+    )
+}
+
+export default QueueVisualization

--- a/pages/index.js
+++ b/pages/index.js
@@ -62,8 +62,7 @@ function Home() {
                         onClick={handlePanel}
                         style={{
                             padding:'0',margin:'0',height:'25px',border:'0',width:'160px',
-                            color:'#333333',fontSize:'13.33px',fontFamily:'Poppins-Light',
-                            borderRadius: '10px'
+                            color:'#333333',fontSize:'13.33px',fontFamily:'Poppins-Light'
                         }}
                     >
                         {panelButtonText}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -56,7 +56,7 @@ body {
 
 button {
     color: #333333;
-    border-radius: 8px;
+    border-radius: 10px;
     border-width: 0;
     cursor: pointer;
     display: inline-block;
@@ -152,6 +152,8 @@ h2 {
 
 p {
     font-size: 0.75em;
+    margin: 0;
+    padding: 0;
 }
 
 table, th, td {
@@ -169,7 +171,6 @@ td {
 }
 
 span {
-    color: transparent;
     height: 10px;
 }
 


### PR DESCRIPTION
* Refactored some states in View (no longer storing strings, but data)

TODO:

- [ ] Queue is larger than CIV_SIZE (waiting list for next dispatch)

## States:

Empty Queue:

<img width="844" alt="Screenshot 2022-08-19 at 21 49 33" src="https://user-images.githubusercontent.com/570771/185699368-8f66cc2f-a691-48b3-a6dd-56dffc0db395.png">

Queue is filling up:

<img width="844" alt="Screenshot 2022-08-19 at 21 52 23" src="https://user-images.githubusercontent.com/570771/185699552-a92f98d7-399e-4325-9f1c-48072471d5af.png">

Queue is filling up, already in queue:  

<img width="844" alt="Screenshot 2022-08-19 at 21 50 09" src="https://user-images.githubusercontent.com/570771/185699392-35eeeb3d-f276-4da7-9f38-61310d1baad0.png">

Full queue, ready to dispatch:

<img width="844" alt="Screenshot 2022-08-19 at 21 50 21" src="https://user-images.githubusercontent.com/570771/185699446-739a3f1d-ac1e-44d0-a00c-45fab6d3425d.png">

Account is already active in the universe:

<img width="844" alt="Screenshot 2022-08-19 at 21 55 25" src="https://user-images.githubusercontent.com/570771/185699653-85f16f4c-f6c1-4ed4-a5fa-c99befaeb756.png">

